### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationManager.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationManager.nuspec
@@ -21,7 +21,7 @@
       <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.27.36284" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.34.44535" />
       <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.26.61682" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.27.36126" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.28.2952" />
       <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.30.34884" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.24.34787" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.31.17475" />
@@ -34,7 +34,7 @@
       <dependency id="nanoFramework.System.Device.Wifi" version="1.5.54" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.38" />
       <dependency id="nanoFramework.System.Net" version="1.10.52" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.84" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.97" />
       <dependency id="nanoFramework.System.Text" version="1.2.37" />
       <dependency id="nanoFramework.System.Threading" version="1.1.19" />
       <dependency id="nanoFramework.Json" version="2.2.99" />

--- a/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/MakoIoT.Device.Services.ConfigurationManager.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/MakoIoT.Device.Services.ConfigurationManager.Test.nfproj
@@ -45,8 +45,9 @@
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.34.44535\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
-    <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.27.36126\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.28.2952\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.30.34884\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
@@ -91,8 +92,9 @@
     <Reference Include="System.Net">
       <HintPath>..\..\packages\nanoFramework.System.Net.1.10.52\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.84\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.97.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.97\lib\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading">
       <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.19\lib\System.Threading.dll</HintPath>

--- a/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.27.36284" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.34.44535" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.27.36126" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.28.2952" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.30.34884" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.24.34787" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.31.17475" targetFramework="netnano1.0" />
@@ -15,7 +15,7 @@
   <package id="nanoFramework.System.Device.Wifi" version="1.5.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.10.52" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.84" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.97" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.19" targetFramework="netnano1.0" />
   <package id="nanoFramework.TestFramework" version="2.1.85" targetFramework="netnano1.0" developmentDependency="true" />

--- a/src/MakoIoT.Device.Services.ConfigurationManager/MakoIoT.Device.Services.ConfigurationManager.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationManager/MakoIoT.Device.Services.ConfigurationManager.nfproj
@@ -49,8 +49,9 @@
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.26.61682\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
     </Reference>
-    <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.27.36126\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.28.2952\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.30.34884\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
@@ -100,8 +101,9 @@
       <HintPath>..\..\packages\nanoFramework.System.Net.1.10.52\lib\System.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.84\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.97.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.97\lib\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.19.33722, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.19\lib\System.Threading.dll</HintPath>

--- a/src/MakoIoT.Device.Services.ConfigurationManager/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationManager/packages.config
@@ -4,7 +4,7 @@
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.27.36284" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.34.44535" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Mediator" version="1.0.26.61682" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.27.36126" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.28.2952" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.30.34884" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.24.34787" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.31.17475" targetFramework="netnano1.0" />
@@ -18,7 +18,7 @@
   <package id="nanoFramework.System.Device.Wifi" version="1.5.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.10.52" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.84" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.97" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.19" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Server from 1.0.27.36126 to 1.0.28.2952</br>Bumps nanoFramework.System.Net.Http from 1.5.84 to 1.5.97</br>
[version update]

### :warning: This is an automated update. :warning:
