### PR TITLE
Update 4 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationManager.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationManager.nuspec
@@ -19,14 +19,14 @@
     <dependencies>
       <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.31.51806" />
       <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.30.32136" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.37.9044" />
       <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.31.54540" />
       <dependency id="MakoIoT.Device.Services.Server" version="1.0.34.13996" />
       <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.36.4164" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.24.34787" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.31.17475" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.0.35" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.14.20" />
+      <dependency id="nanoFramework.DependencyInjection" version="1.1.1" />
       <dependency id="nanoFramework.Iot.Device.DhcpServer" version="1.2.378" />
       <dependency id="nanoFramework.Logging" version="1.1.63" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.6" />

--- a/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/MakoIoT.Device.Services.ConfigurationManager.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/MakoIoT.Device.Services.ConfigurationManager.Test.nfproj
@@ -44,7 +44,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.36.21434\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.38.18612\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -61,11 +61,12 @@
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.31.17475\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.14.20.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.20\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.0.35.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.0.35\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.1\lib\nanoFramework.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Logging">

--- a/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.30.32136" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.38.18612" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Server" version="1.0.34.13996" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.36.4164" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.24.34787" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.31.17475" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
-  <package id="nanoFramework.DependencyInjection" version="1.0.35" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.20" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.378" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.63" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.6" targetFramework="netnano1.0" />

--- a/src/MakoIoT.Device.Services.ConfigurationManager/MakoIoT.Device.Services.ConfigurationManager.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationManager/MakoIoT.Device.Services.ConfigurationManager.nfproj
@@ -45,7 +45,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.36.21434\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.37.9044\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -66,12 +66,12 @@
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.31.17475\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.14.20.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.20\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.0.35.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.0.35\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.1\lib\nanoFramework.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Json, Version=2.2.101.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Services.ConfigurationManager/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationManager/packages.config
@@ -2,14 +2,14 @@
 <packages>
   <package id="MakoIoT.Device.Services.Configuration" version="1.0.31.51806" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.30.32136" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.37.9044" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Mediator" version="1.0.31.54540" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Server" version="1.0.34.13996" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.36.4164" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.24.34787" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.31.17475" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
-  <package id="nanoFramework.DependencyInjection" version="1.0.35" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.20" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.378" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.101" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.63" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.36.21434 to 1.0.37.9044</br>Bumps nanoFramework.CoreLibrary from 1.14.2 to 1.14.20</br>Bumps nanoFramework.DependencyInjection from 1.0.35 to 1.1.1</br>Bumps MakoIoT.Device.Services.Interface from 1.0.36.21434 to 1.0.38.18612</br>
[version update]

### :warning: This is an automated update. :warning:
