### PR TITLE
Update 6 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationManager.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationManager.nuspec
@@ -17,12 +17,12 @@
     <description>Configuration mode manager for MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot configuration wifimanager</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.32.19851" />
-      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.35.8833" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.41.25178" />
-      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.32.35604" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.39.37862" />
-      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.38.49935" />
+      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.33.44373" />
+      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.36.60910" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.42.48151" />
+      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.33.12388" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.40.55148" />
+      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.39.20890" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.27.50780" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />

--- a/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/MakoIoT.Device.Services.ConfigurationManager.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/MakoIoT.Device.Services.ConfigurationManager.Test.nfproj
@@ -40,18 +40,19 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.35.8833\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.36.60910\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.41.25178\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.42.48151\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MakoIoT.Device.Services.Server">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.39.37862\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.40.55148\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.38.49935\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.39.20890\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker">

--- a/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.35.8833" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.41.25178" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.39.37862" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.38.49935" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.36.60910" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.42.48151" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.40.55148" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.39.20890" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.27.50780" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />

--- a/src/MakoIoT.Device.Services.ConfigurationManager/MakoIoT.Device.Services.ConfigurationManager.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationManager/MakoIoT.Device.Services.ConfigurationManager.nfproj
@@ -36,26 +36,28 @@
       <HintPath>..\..\packages\nanoFramework.Iot.Device.DhcpServer.1.2.407\lib\Iot.Device.DhcpServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MakoIoT.Device.Services.Configuration">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.32.19851\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.33.44373\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.35.8833\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.36.60910\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.41.25178\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.42.48151\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.32.35604\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.33.12388\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MakoIoT.Device.Services.Server">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.39.37862\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.40.55148\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.38.49935\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.39.20890\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker">

--- a/src/MakoIoT.Device.Services.ConfigurationManager/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationManager/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Configuration" version="1.0.32.19851" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.35.8833" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.41.25178" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Mediator" version="1.0.32.35604" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.39.37862" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.38.49935" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration" version="1.0.33.44373" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.36.60910" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.42.48151" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Mediator" version="1.0.33.12388" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.40.55148" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.39.20890" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.27.50780" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Configuration from 1.0.32.19851 to 1.0.33.44373</br>Bumps MakoIoT.Device.Services.Configuration.Metadata from 1.0.35.8833 to 1.0.36.60910</br>Bumps MakoIoT.Device.Services.Interface from 1.0.41.25178 to 1.0.42.48151</br>Bumps MakoIoT.Device.Services.Mediator from 1.0.32.35604 to 1.0.33.12388</br>Bumps MakoIoT.Device.Services.Server from 1.0.39.37862 to 1.0.40.55148</br>Bumps MakoIoT.Device.Services.WiFi.AP from 1.0.38.49935 to 1.0.39.20890</br>
[version update]

### :warning: This is an automated update. :warning:
