### PR TITLE
Update 5 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationManager.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationManager.nuspec
@@ -18,11 +18,11 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot configuration wifimanager</tags>
     <dependencies>
       <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.61.54678" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" />
-      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.55.2648" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.75.10164" />
-      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.88.6279" />
-      <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.40.10358" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.48.22567" />
+      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.56.4697" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.76.26071" />
+      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.89.18478" />
+      <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.41.39143" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.37.35071" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.11" />

--- a/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/MakoIoT.Device.Services.ConfigurationManager.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/MakoIoT.Device.Services.ConfigurationManager.Test.nfproj
@@ -39,16 +39,16 @@
       <HintPath>..\..\packages\nanoFramework.Iot.Device.DhcpServer.1.2.644\lib\Iot.Device.DhcpServer.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.47.44904\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.48.22567\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.75.10164\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.76.26071\lib\MakoIoT.Device.Services.Server.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.88.6279\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.89.18478\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.40.10358\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.41.39143\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.37.35071\lib\MakoIoT.Device.Utilities.String.dll</HintPath>

--- a/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.75.10164" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.88.6279" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.40.10358" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.48.22567" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.76.26071" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.89.18478" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.41.39143" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.37.35071" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.11" targetFramework="netnano1.0" />

--- a/src/MakoIoT.Device.Services.ConfigurationManager/MakoIoT.Device.Services.ConfigurationManager.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationManager/MakoIoT.Device.Services.ConfigurationManager.nfproj
@@ -39,19 +39,19 @@
       <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.61.54678\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.47.44904\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.48.22567\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.55.2648\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.56.4697\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.75.10164\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.76.26071\lib\MakoIoT.Device.Services.Server.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.88.6279\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.89.18478\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.40.10358\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.41.39143\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.37.35071\lib\MakoIoT.Device.Utilities.String.dll</HintPath>

--- a/src/MakoIoT.Device.Services.ConfigurationManager/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationManager/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Services.Configuration" version="1.0.61.54678" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Mediator" version="1.0.55.2648" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.75.10164" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.88.6279" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.40.10358" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.48.22567" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Mediator" version="1.0.56.4697" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.76.26071" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.89.18478" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.41.39143" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.37.35071" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.11" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.47.44904 to 1.0.48.22567</br>Bumps MakoIoT.Device.Services.Mediator from 1.0.55.2648 to 1.0.56.4697</br>Bumps MakoIoT.Device.Services.Server from 1.0.75.10164 to 1.0.76.26071</br>Bumps MakoIoT.Device.Services.WiFi.AP from 1.0.88.6279 to 1.0.89.18478</br>Bumps MakoIoT.Device.Utilities.Invoker from 1.0.40.10358 to 1.0.41.39143</br>
[version update]

### :warning: This is an automated update. :warning:
