### PR TITLE
Update 7 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationManager.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationManager.nuspec
@@ -17,16 +17,16 @@
     <description>Configuration mode manager for MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot configuration wifimanager</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.68.40789" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.53.21413" />
+      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.69.15488" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" />
       <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.61.19880" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.83.49925" />
-      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.97.55003" />
-      <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.44.64291" />
-      <dependency id="MakoIoT.Device.Utilities.String" version="1.0.40.2867" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.84.30825" />
+      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.98.27130" />
+      <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.45.30811" />
+      <dependency id="MakoIoT.Device.Utilities.String" version="1.0.42.9118" />
       <dependency id="nanoFramework.CoreLibrary" version="1.17.7" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.30" />
-      <dependency id="nanoFramework.Iot.Device.DhcpServer" version="1.2.809" />
+      <dependency id="nanoFramework.Iot.Device.DhcpServer" version="1.2.823" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.31" />
       <dependency id="nanoFramework.System.Collections" version="1.5.63" />
       <dependency id="nanoFramework.System.Device.Wifi" version="1.5.128" />

--- a/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/MakoIoT.Device.Services.ConfigurationManager.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/MakoIoT.Device.Services.ConfigurationManager.Test.nfproj
@@ -36,22 +36,22 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Iot.Device.DhcpServer, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Iot.Device.DhcpServer.1.2.809\lib\Iot.Device.DhcpServer.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.Iot.Device.DhcpServer.1.2.823\lib\Iot.Device.DhcpServer.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.54.39044\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.83.49925\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.84.30825\lib\MakoIoT.Device.Services.Server.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.97.55003\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.98.27130\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.44.64291\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.45.30811\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.40.2867\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.42.9118\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.17.7.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.7\lib\mscorlib.dll</HintPath>

--- a/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.83.49925" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.97.55003" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.44.64291" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.String" version="1.0.40.2867" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.84.30825" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.98.27130" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.45.30811" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.String" version="1.0.42.9118" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.7" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.30" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.809" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.823" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.31" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.63" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Device.Wifi" version="1.5.128" targetFramework="netnano1.0" />

--- a/src/MakoIoT.Device.Services.ConfigurationManager/MakoIoT.Device.Services.ConfigurationManager.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationManager/MakoIoT.Device.Services.ConfigurationManager.nfproj
@@ -33,28 +33,28 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Iot.Device.DhcpServer, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Iot.Device.DhcpServer.1.2.809\lib\Iot.Device.DhcpServer.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.Iot.Device.DhcpServer.1.2.823\lib\Iot.Device.DhcpServer.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.68.40789\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.69.15488\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.53.21413\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.54.39044\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.61.19880\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.83.49925\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.84.30825\lib\MakoIoT.Device.Services.Server.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.97.55003\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.98.27130\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.44.64291\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.45.30811\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.40.2867\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.42.9118\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.17.7.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.7\lib\mscorlib.dll</HintPath>

--- a/src/MakoIoT.Device.Services.ConfigurationManager/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationManager/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Configuration" version="1.0.68.40789" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.53.21413" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration" version="1.0.69.15488" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Mediator" version="1.0.61.19880" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.83.49925" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.97.55003" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.44.64291" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.String" version="1.0.40.2867" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.84.30825" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.98.27130" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.45.30811" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.String" version="1.0.42.9118" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.7" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.30" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.809" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.823" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.189" />
   <package id="nanoFramework.Runtime.Events" version="1.11.31" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.63" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Configuration from 1.0.68.40789 to 1.0.69.15488</br>Bumps MakoIoT.Device.Services.Interface from 1.0.53.21413 to 1.0.54.39044</br>Bumps MakoIoT.Device.Services.Server from 1.0.83.49925 to 1.0.84.30825</br>Bumps MakoIoT.Device.Services.WiFi.AP from 1.0.97.55003 to 1.0.98.27130</br>Bumps MakoIoT.Device.Utilities.Invoker from 1.0.44.64291 to 1.0.45.30811</br>Bumps MakoIoT.Device.Utilities.String from 1.0.40.2867 to 1.0.42.9118</br>Bumps nanoFramework.Iot.Device.DhcpServer from 1.2.809 to 1.2.823</br>
[version update]

### :warning: This is an automated update. :warning:
