### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/MakoIoT.Device.Services.ConfigurationManager.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/MakoIoT.Device.Services.ConfigurationManager.Test.nfproj
@@ -68,11 +68,11 @@
     <Reference Include="nanoFramework.System.Text, Version=1.3.36.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.3.36\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=3.0.69.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.69\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=3.0.73.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.73\lib\nanoFramework.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.69\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.73\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
     </Reference>
     <Reference Include="System.Device.Wifi, Version=1.5.128.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.128\lib\System.Device.Wifi.dll</HintPath>

--- a/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/packages.config
@@ -16,5 +16,5 @@
   <package id="nanoFramework.System.Net.Http" version="1.5.189" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.36" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.50" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="3.0.69" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="3.0.73" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.TestFramework from 3.0.69 to 3.0.73</br>
[version update]

### :warning: This is an automated update. :warning:
