### PR TITLE
Update 4 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationManager.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationManager.nuspec
@@ -17,11 +17,11 @@
     <description>Configuration mode manager for MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot configuration wifimanager</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.78.14004" />
+      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.79.50784" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.57.48509" />
-      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.69.44310" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.97.63898" />
-      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.110.35596" />
+      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.70.28908" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.98.18895" />
+      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.111.27240" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.49.58921" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.44.38123" />
       <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />

--- a/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/MakoIoT.Device.Services.ConfigurationManager.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/MakoIoT.Device.Services.ConfigurationManager.Test.nfproj
@@ -42,10 +42,10 @@
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.57.48509\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.97.63898\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.98.18895\lib\MakoIoT.Device.Services.Server.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.110.35596\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.111.27240\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.49.58921\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>

--- a/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.ConfigurationManager.Test/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Services.Interface" version="1.0.57.48509" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.97.63898" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.110.35596" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.98.18895" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.111.27240" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.49.58921" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.44.38123" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />

--- a/src/MakoIoT.Device.Services.ConfigurationManager/MakoIoT.Device.Services.ConfigurationManager.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationManager/MakoIoT.Device.Services.ConfigurationManager.nfproj
@@ -36,19 +36,19 @@
       <HintPath>..\..\packages\nanoFramework.Iot.Device.DhcpServer.1.2.851\lib\Iot.Device.DhcpServer.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.78.14004\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.79.50784\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.57.48509\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.69.44310\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.70.28908\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.97.63898\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.98.18895\lib\MakoIoT.Device.Services.Server.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.110.35596\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.111.27240\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.49.58921\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>

--- a/src/MakoIoT.Device.Services.ConfigurationManager/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationManager/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Configuration" version="1.0.78.14004" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration" version="1.0.79.50784" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.57.48509" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Mediator" version="1.0.69.44310" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.97.63898" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.110.35596" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Mediator" version="1.0.70.28908" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.98.18895" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.111.27240" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.49.58921" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.44.38123" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Configuration from 1.0.78.14004 to 1.0.79.50784</br>Bumps MakoIoT.Device.Services.Mediator from 1.0.69.44310 to 1.0.70.28908</br>Bumps MakoIoT.Device.Services.Server from 1.0.97.63898 to 1.0.98.18895</br>Bumps MakoIoT.Device.Services.WiFi.AP from 1.0.110.35596 to 1.0.111.27240</br>
[version update]

### :warning: This is an automated update. :warning:
